### PR TITLE
Fix mkdocs build: move blogging locale/time_format under the plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ plugins:
         - Blog/blog_template.md
   - blogging:
       template: templates/aucloud_blog.html
+      locale: en # babel locale for date localization; without it the runner's LC_TIME=C breaks newer babel (UnknownLocaleError: 'c')
+      time_format: "%Y-%m-%d %H:%M:%S" # The format used to display the time
+      meta_time_format: "%Y-%m-%d %H:%M:%S"
 
       features:
         tags: {}
@@ -110,9 +113,6 @@ site_description: AUCyber's technical documentation site, managed as code from G
 site_name: Technical Documentation
 site_url: !ENV SITE_URL
 theme:
-  locale: en # The locale for time localizations, default: system's locale
-  time_format: "%Y-%m-%d %H:%M:%S" # The format used to display the time
-  meta_time_format: "%Y-%m-%d %H:%M:%S"
   logo: aucyber.svg
   favicon: images/favicon.ico
   features:


### PR DESCRIPTION
## Problem
The **Build the website** workflow fails at `make docs-validate` (`mkdocs build -c -s`):

```
babel.core.UnknownLocaleError: unknown locale 'c'
  mkdocs_blogging_plugin/util.py get_localized_date -> babel format_datetime(locale=_locale)
```

The `mkdocs-blogging-plugin` had **no `locale` set**, so it fell back to the CI runner's `LC_TIME=C`. Newer `babel` rejects the `C` locale (older versions silently treated it as English), which is why a previously-green build started failing.

## Root cause
`locale`, `time_format` and `meta_time_format` were nested under **`theme:`**, where mkdocs-material ignores them — so they never reached the blogging plugin.

## Fix
Move the three keys under the `- blogging:` plugin so `locale: en` actually applies (also makes the intended `time_format` take effect). No rendered-content change beyond the (previously non-functional) date format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)