### PR TITLE
docs: update M365 Veeam app registration to VB365 v8 app-only auth

### DIFF
--- a/docs/Platform_Services/M365_Backup/EntraID_application_permission_requirements.md
+++ b/docs/Platform_Services/M365_Backup/EntraID_application_permission_requirements.md
@@ -8,41 +8,52 @@ tags:
 
 ## Permissions for Modern App-Only Authentication
 
-Tables in this section list permissions for Entra ID applications that are granted automatically by Veeam Backup for Microsoft Office 365 when you add organizations using the [modern app-only authentication method](https://helpcenter.veeam.com/docs/vbo365/guide/adding_o365_organizations_sd.html).
+Tables in this section list the permissions required by the Microsoft Entra ID application that AUCyber's M365 Backup service uses with the [modern app-only authentication method](https://helpcenter.veeam.com/docs/vbo365/guide/adding_o365_organizations_sd.html?ver=8).
+
+Restores are performed using the Entra ID application certificate, so every permission listed on this page is of the **Application** type. No delegated permissions are required. Grant the permissions from both tables to the same application.
+
+!!! warning "Exchange Web Services (EWS) retirement"
+
+    Microsoft disables EWS in Exchange Online on 1 October 2026. The Microsoft Graph permissions listed below (User.Read.All, MailboxItem.ImportExport.All, MailboxFolder.ReadWrite.All and MailboxItem.Read.All) allow Exchange data to be backed up and restored through the Microsoft Graph API instead of EWS, and must be in place before that date. See the [Veeam support statement](https://www.veeam.com/kb4820) for details.
 
 ## Permissions for Backup
 
-All listed permissions are of the **Application** type.
-
-| API      |    Permission Name |  Exchange Online | SharePoint Online and OneDrive for Business | Microsoft Teams | Description |
+| API      |    Permission Name |  Exchange Online | SharePoint Online and Microsoft OneDrive | Microsoft Teams | Description |
 | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| Microsoft Graph | Directory.Read.All | ✔ | ✔ | ✔ | Querying Azure AD for organization properties, the list of users and groups and their properties.|
-| | Group.Read.Write.All|  | ✔ | ✔ | Querying Azure AD for the list of groups and group sites.|
-| | Sites.Read.All |  | ✔ | ✔ | Querying Azure AD for the list of sites and getting download URLs for files and their versions.|
+| Microsoft Graph | Directory.Read.All | ✔ | ✔ | ✔ | Querying Microsoft Entra ID for organization properties, the list of users and groups and their properties.|
+| | Group.Read.All | ✔ | ✔ | ✔ | Querying Microsoft Entra ID for the list of groups and group sites.|
+| | Sites.Read.All |  | ✔ | ✔ | Querying Microsoft Entra ID for the list of sites and getting download URLs for files and their versions.|
 | | TeamSettings.ReadWrite.All |  |  | ✔ | Accessing archived teams.|
-| | ChannelMessage.Read.All |  |  | ✔ | Accessing all Teams public channel messages. Note: This permission is only required if you want to back up team chats using Teams Export APIs. For more information, see [Organization Object Types](https://helpcenter.veeam.com/docs/vbo365/guide/vbo_object_types.html#team_chats).|
-| Office 365 Exchange Online[^1] |Full Access As App | ✔ |  | ✔ | Reading mailboxes content. |
-|  |Exchange.ManageAsApp | ✔ |  |  | 	Accessing Exchange Online PowerShell to do the following: Back up public folder and discovery search mailboxes and determine object type for shared mailboxes as Shared Mailbox. |
-| SharePoint | Sites.FullControl.All |  | ✔ | ✔ | Reading SharePoint sites and OneDrive accounts content. |
-|  | User.Read.All |  | ✔ | ✔ | Reading OneDrive accounts (getting site IDs). Note: This permission is not used to back up Microsoft Teams data, but you must grant it along with SharePoint Online and OneDrive for Business permission to add Microsoft 365 organization successfully. |
-
-[^1]:
-    You can check permissions for Office 365 Exchange Online API. For more information, see [Checking Permissions for Office 365 Exchange Online API](https://helpcenter.veeam.com/docs/vbo365/guide/permissions_exchange_online_api_checking.html).
+| | ChannelMessage.Read.All |  |  | ✔ | Accessing Microsoft Teams public channel messages.|
+| | ChannelMember.Read.All |  |  | ✔ | Accessing Microsoft Teams private and shared channels.|
+| | User.Read.All | ✔ |  |  | Accessing Exchange mailboxes that belong to a user (getting mailbox IDs).|
+| | MailboxItem.ImportExport.All | ✔ |  |  | Exporting Exchange mailbox item data and creating a session to import an Exchange mailbox item.|
+| | MailboxFolder.ReadWrite.All | ✔ |  |  | Accessing Exchange mailbox folders.|
+| | MailboxItem.Read.All | ✔ |  |  | Accessing Exchange mailbox items: getting item properties, and getting items that were added, deleted or updated in a mailbox folder.|
+| Office 365 Exchange Online[^1] | full_access_as_app | ✔ |  | ✔ | Reading mailboxes content. |
+| | Exchange.ManageAsApp | ✔ |  |  | Accessing Exchange Online PowerShell to back up public folder and discovery search mailboxes, and to determine the object type for shared mailboxes as Shared Mailbox. This permission works along with the Global Reader role granted to the application. |
+| Office 365 SharePoint Online | Sites.FullControl.All |  | ✔ | ✔ | Reading SharePoint sites and OneDrive accounts content. |
+| | User.Read.All |  | ✔ | ✔ | Reading OneDrive accounts (getting site IDs). Note: This permission is not used to back up Microsoft Teams data, but you must grant it along with the SharePoint Online and OneDrive permissions to add a Microsoft 365 organization successfully. |
 
 ## Permissions for Restore
 
-All listed permissions are of the **Delegated** type and required for data restore using Veeam Explorers.
+Restores use the Entra ID application certificate, so these permissions are also of the **Application** type.
 
-| API      |    Permission Name |  Exchange Online | SharePoint Online and OneDrive for Business | Microsoft Teams | Description |
+| API      |    Permission Name |  Exchange Online | SharePoint Online and Microsoft OneDrive | Microsoft Teams | Description |
 | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| Microsoft Graph | Directory.Read.All | ✔ | ✔ | ✔ | Querying Azure AD for organization properties, the list of users and groups and their properties.|
-| | Group.ReadWrite.All |  |  | ✔ | Recreating in Azure AD an associated group in case of teams restore.|
+| Microsoft Graph | Directory.Read.All | ✔ |  | ✔ | Querying Microsoft Entra ID for organization properties, the list of users and groups and their properties.|
+| | Group.ReadWrite.All |  | ✔ | ✔ | Recreating an associated group in Microsoft Entra ID in case of a deleted team site restore. Note: This permission is only required for restore of SharePoint site data through REST API and PowerShell.|
 | | Sites.Read.All |  | ✔ | ✔ | Accessing sites of the applications that are installed from the SharePoint store.|
-| | Directory.ReadWrite.All |  |  | ✔ | Setting the preferred data location when creating a new M365 group for a multi-geo tenant in case of teams restore.|
-| | Offline Access | ✔ | ✔ | ✔ | Obtaining a refresh token from Azure AD.|
-| Office 365 Exchange Online[^1] | EWS.AccessAsUser.All | ✔ |  |  | Accessing mailboxes as the signed-in user (impersonation) through EWS.|
-| SharePoint | AllSites.FullControl |  | ✔ | ✔ | Reading the current state and restoring SharePoint sites and OneDrive accounts content.|
-|  | User.Read.All |  | ✔ |  | Resolving OneDrive accounts (getting site IDs). Note: This permission is not required to restore SharePoint Online data.|
+| | Directory.ReadWrite.All |  | ✔ | ✔ | Setting the preferred data location and creating sites that have Microsoft Teams templates, when creating or accessing a M365 group for a Multi-Geo tenant.|
+| | Files.ReadWrite.All |  |  | ✔ | Reading the current state and restoring files of Microsoft Teams shared channels.|
+| | ChannelMember.ReadWrite.All |  |  | ✔ | Reading the current state and restoring Microsoft Teams private and shared channels.|
+| | User.Read.All | ✔ |  |  | Accessing Exchange mailboxes that belong to a user (getting mailbox IDs).|
+| | MailboxItem.ImportExport.All | ✔ |  |  | Exporting Exchange mailbox item data and creating a session to import an Exchange mailbox item.|
+| | MailboxFolder.ReadWrite.All | ✔ |  |  | Accessing Exchange mailbox folders: reading folder properties, getting folders that were added, deleted or removed, and creating a new folder or subfolder in a user mailbox.|
+| | MailboxItem.Read.All | ✔ |  |  | Accessing Exchange mailbox items: getting item properties, and getting items that were added, deleted or updated in a mailbox folder.|
+| Office 365 Exchange Online[^1] | full_access_as_app | ✔ |  |  | Reading the current state and restoring mailboxes content.|
+| Office 365 SharePoint Online | Sites.FullControl.All |  | ✔ | ✔ | Reading the current state and restoring SharePoint sites and OneDrive accounts content.|
+| | User.Read.All |  | ✔ |  | Resolving OneDrive accounts (getting site IDs). Note: This permission is not required to restore SharePoint Online data.|
 
 [^1]:
-    You can check permissions for Office 365 Exchange Online API. For more information, see [Checking Permissions for Office 365 Exchange Online API](https://helpcenter.veeam.com/docs/vbo365/guide/permissions_exchange_online_api_checking.html).
+    You can check permissions for Office 365 Exchange Online API. For more information, see [Checking Permissions for Office 365 Exchange Online API](https://helpcenter.veeam.com/docs/vbo365/guide/permissions_exchange_online_api_checking.html?ver=8).

--- a/docs/Platform_Services/M365_Backup/configuration.md
+++ b/docs/Platform_Services/M365_Backup/configuration.md
@@ -1,47 +1,40 @@
 ---
 title: Configuration of Microsoft M365 Veeam Backup App Registration
-description: Configuration of Microsoft M365 Service Account
+description: Configuration of the Microsoft Entra ID application for AUCyber's M365 Backup as a Service
 tags:
  - M365
  - Backup
  - Veeam
 ---
 
-## Information on how to configure your M365 service account for AUCyber's M365 Backup as a Service
+## Information on how to configure your M365 tenant for AUCyber's M365 Backup as a Service
 
 This guide outlines the steps required to configure and implement your Microsoft 365 Backup with AUCyber
-using the modern authentication method. You will be allocated a Customer Success Manager (CSM) who
-will assist you with the on-boarding process, provide advice and act as a conduit to deeper technical support
-when required.
+using the modern app-only authentication method. Backup and restore both authenticate with a certificate
+against a Microsoft Entra ID application registered in your tenant, so no backup service account is
+required. You will be allocated a Customer Success Manager (CSM) who will assist you with the
+on-boarding process, provide advice and act as a conduit to deeper technical support when required.
 
 ## Prerequisites
 
-- Customers must have a Microsoft Office 365 account that has an active subscription.
-- The Microsoft Office 365 account used for configuration must have permission to manage applications in Entra ID (formerly known as Active Directory). Any of the following Entra ID roles include the required permissions:
+- Customers must have a Microsoft 365 account that has an active subscription.
+- The account used for configuration must have permission to manage applications in Microsoft Entra ID (formerly Azure Active Directory). Any of the following Entra ID roles include the required permissions:
 
-    * [Application administrator](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#application-administrator)
-    * [Application developer](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#application-developer)
-    * [Cloud application administrator](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#cloud-application-administrator)
+    * [Application administrator](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#application-administrator)
+    * [Application developer](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#application-developer)
+    * [Cloud application administrator](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#cloud-application-administrator)
 
-- Navigate to [portal.azure.com](https://portal.azure.com) to begin and click on **Azure Entra ID**
-- [Create a backup service account](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/how-to-create-delete-users) in Azure Entra ID (eg. backup@domain.com)
-- [Assign roles](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/users-assign-role-azure-portal) to the service account with the following assignments:
+- Granting tenant-wide admin consent to the application permissions requires a Global Administrator.
+- AUCyber will provide you with a certificate (public key) to be used during application registration. This certificate is used to authenticate both backup and restore operations.
+- Configuration is performed in the [Microsoft Entra admin center](https://entra.microsoft.com).
 
-    * Global Reader
-    * Exchange Administrator
-    * Sharepoint Administrator
-    * Teams Administrator
-
-- AUCyber will provide you with a certificate (public key) to be used during application registration.
-
-
-## Azure Entra ID Application permissions
+## Microsoft Entra ID application permissions
 
 ### Register an application
 
-1. In the Microsoft Office 365 Admin Centre, navigate to **Azure Entra ID**.
-1. Under **Manage**, select **App registrations** > **New registration**.
-1. Enter a display **Name** and select the **Accounts in this organizational directory
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com), go to **Identity** > **Applications** > **App registrations**.
+1. Select **New registration**.
+1. Enter a display **Name** and select **Accounts in this organizational directory
 only**.
 
     !!! note
@@ -56,76 +49,57 @@ registration.
 
 ### Grant Global Reader permission
 
-To grant the Global Reader role to the Azure Entra ID application, do the following:
+The Global Reader role must be assigned to the application itself. It is required by the
+Exchange.ManageAsApp permission to back up public folder and discovery search mailboxes. To grant the
+role, do the following:
 
-3.    Sign in to the Azure portal.
-
-4.    Go to **Microsoft Entra Admin Centre** > **Roles and admins**.
+1. In the [Microsoft Entra admin center](https://entra.microsoft.com), go to **Identity** > **Roles & admins** > **Roles & admins**.
 
     ![M365 Global Reader Assignment](./assets/m365-global-reader-assignment.png)
 
-5.    In the **Administrative roles** list, find the **Global Reader** role and click on it.
-
-6.    In the **Global Reader** window, click **Add assignments**.
-
-The **Add assignment** wizard runs.
-
-1.    In the **Select member(s)** section, click the link.
-
-2.    In the **Select a member** window, select the Azure Entra ID application in the list and click **Select**.
-
-The selected application appears in the **Selected member(s)** list.
-
-1.    Click **Next** and then **Assign** to finish the wizard.
+1. In the **Administrative roles** list, find the **Global Reader** role and click on it.
+1. In the **Global Reader** window, click **Add assignments**.
+1. In the **Select member(s)** section, click the link.
+1. In the **Select a member** window, select the application you registered and click **Select**.
+1. The selected application appears in the **Selected member(s)** list.
+1. Click **Next** and then **Assign** to finish the wizard.
 
 ### Configure Application permissions
 
-Select the newly registered application, select API permissions, and add permissions for:
+Select the newly registered application, select **API permissions**, and add permissions for:
 
 - Microsoft Graph
 - Office 365 Exchange Online
-- SharePoint
+- Office 365 SharePoint Online
 
     !!! note
 
-        To search for other API, select **APIs my organisation uses**.
+        To search for other APIs, select **APIs my organisation uses**.
 
 ![API Permissions](./assets/api_permissions.png)
 
-For each API e.g., Microsoft graph, add the appropriate delegated (restore) and application (backup) type permissions as per below:
+All required permissions are of the **Application** type. Delegated permissions are not required:
+restores are performed using the application certificate, not a signed-in user.
 
 ![Request API Permissions](./assets/request_api_permission.png)
-  
-1. [**Delegated (restore) permissions**](./EntraID_application_permission_requirements.md#permissions-for-restore)
 
-| API      |    Permission Name |  Exchange Online | SharePoint Online and OneDrive for Business | Microsoft Teams | Description |
-| ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| Microsoft Graph | Directory.Read.All | ✔ | ✔ | ✔ | Querying Azure AD for organization properties, the list of users and groups and their properties.|
-| | Group.ReadWrite.All |  |  | ✔ | Recreating in Azure AD an associated group in case of teams restore.|
-| | Sites.Read.All |  | ✔ | ✔ | Accessing sites of the applications that are installed from the SharePoint store.|
-| | Directory.ReadWrite.All |  |  | ✔ | Setting the preferred data location when creating a new M365 group for a multi-geo tenant in case of teams restore.|
-| | Offline Access | ✔ | ✔ | ✔ | Obtaining a refresh token from Azure AD.|
-| Office 365 Exchange Online[^1] | EWS.AccessAsUser.All | ✔ |  |  | Accessing mailboxes as the signed-in user (impersonation) through EWS.|
-| SharePoint | AllSites.FullControl |  | ✔ | ✔ | Reading the current state and restoring SharePoint sites and OneDrive accounts content.|
-|  | User.Read.All |  | ✔ |  | Resolving OneDrive accounts (getting site IDs). Note: This permission is not required to restore SharePoint Online data.|
+Add every permission listed in both tables on the
+[Entra ID Application Permission Requirements](./EntraID_application_permission_requirements.md) page:
 
-1. [**Application (backup) permissions**](./EntraID_application_permission_requirements.md#permissions-for-backup)
+1. [Permissions for backup](./EntraID_application_permission_requirements.md#permissions-for-backup)
+1. [Permissions for restore](./EntraID_application_permission_requirements.md#permissions-for-restore)
 
-| API      |    Permission Name |  Exchange Online | SharePoint Online and OneDrive for Business | Microsoft Teams | Description |
-| ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
-| Microsoft Graph | Directory.Read.All | ✔ | ✔ | ✔ | Querying Azure AD for organization properties, the list of users and groups and their properties.|
-| | Group.Read.Write.All|  | ✔ | ✔ | Querying Azure AD for the list of groups and group sites.|
-| | Sites.Read.All |  | ✔ | ✔ | Querying Azure AD for the list of sites and getting download URLs for files and their versions.|
-| | TeamSettings.ReadWrite.All |  |  | ✔ | Accessing archived teams.|
-| | ChannelMessage.Read.All |  |  | ✔ | Accessing all Teams public channel messages. Note: This permission is only required if you want to back up team chats using Teams Export APIs. For more information, see [Organization Object Types](https://helpcenter.veeam.com/docs/vbo365/guide/vbo_object_types.html#team_chats).|
-| Office 365 Exchange Online[^1] |Full Access As App | ✔ |  | ✔ | Reading mailboxes content. |
-|  |Exchange.ManageAsApp | ✔ |  |  | 	Accessing Exchange Online PowerShell to do the following: Back up public folder and discovery search mailboxes and determine object type for shared mailboxes as Shared Mailbox. |
-| SharePoint | Sites.FullControl.All |  | ✔ | ✔ | Reading SharePoint sites and OneDrive accounts content. |
-|  | User.Read.All |  | ✔ | ✔ | Reading OneDrive accounts (getting site IDs). Note: This permission is not used to back up Microsoft Teams data, but you must grant it along with SharePoint Online and OneDrive for Business permission to add Microsoft 365 organization successfully. |
+!!! warning "Exchange Web Services (EWS) retirement"
 
-1. After all APIs are added, you will need to **grant admin consent**
+    Microsoft disables EWS in Exchange Online on 1 October 2026. The Microsoft Graph mailbox
+    permissions in the tables (User.Read.All, MailboxItem.ImportExport.All, MailboxFolder.ReadWrite.All
+    and MailboxItem.Read.All) allow Exchange data to be backed up and restored through the Microsoft
+    Graph API instead of EWS. Make sure they are granted, otherwise Exchange backups will fail once
+    Microsoft retires EWS.
 
-   ![Grant Admin Consent](./assets/grant_admin_consent.png)
+After all permissions are added, you will need to **grant admin consent**:
+
+![Grant Admin Consent](./assets/grant_admin_consent.png)
 
 ### Add a Certificate (public key)
 
@@ -144,10 +118,12 @@ For each API e.g., Microsoft graph, add the appropriate delegated (restore) and 
 
 ### Join secure meeting with AUCyber
 
-A joint session with the AUCyber technical team is required for you to enter the necessary credentials to finalise the configuration of the Veeam Backup for Office 365 application. This can be organised via Webex, Zoom, Teams chat or face-to-face meeting. Please advise your CSM on what suits best.
+A joint session with the AUCyber technical team is required for you to provide the details needed to
+finalise the configuration of the Veeam Backup for Microsoft 365 application. This can be organised via
+Webex, Zoom, Teams chat or face-to-face meeting. Please advise your CSM on what suits best.
 
-- Service account username
-- Application ID
+- Application (client) ID of the registered application
+- Your Microsoft 365 organization name (for example contoso.onmicrosoft.com)
 
   ![Edit Organisation](./assets/edit_organisation.png)
 
@@ -157,7 +133,7 @@ To access the Veeam restore portal, you must add an Enterprise Application in En
 
 #### Prerequisite
 
-For the below, you need to use a Service Account with enough rights to perform an Enterprise Application install on Entra ID. In order to perform these steps, we will need the Entra ID PowerShell cmdlet. To install this, open PowerShell and run the following command:
+For the below, you need to use an account with enough rights to perform an Enterprise Application install on Entra ID. In order to perform these steps, we will need the Microsoft Graph PowerShell module. To install this, open PowerShell and run the following command:
 
 ```
 Install-Module Microsoft.Graph -Scope CurrentUser -Force
@@ -174,7 +150,7 @@ Connect-MgGraph -Scopes "Application.ReadWrite.All"
 ```
 
 This will open a traditional username and password Microsoft popup:
-Please enter your service account username and password in this popup including MFA if prompted.
+Please enter your username and password in this popup including MFA if prompted.
 
 We should see something like this if everything worked smoothly:
 
@@ -192,12 +168,12 @@ If everything works as expected, the output should show something similar to thi
 
 !!! note
 
-    If you receive an error that the application ID already exists, you must delete the pre-existing Enterprise Application ‘Veeam VBO’ from your Entra ID and then repeat the above command.
+    If you receive an error that the application ID already exists, you must delete the pre-existing Enterprise Application 'Veeam VBO' from your Entra ID and then repeat the above command.
 
 
 **Last-Step - Give permission to the new Application on Entra ID**
 
-- Under Enterprise Applications, remove the enterprise applications filter, and order them by date.
+- In the [Microsoft Entra admin center](https://entra.microsoft.com), go to **Identity** > **Applications** > **Enterprise applications**, remove the application type filter, and order by created date.
 
 You should see a new Veeam VBO application (the name of the Restore Portal).
 

--- a/docs/Platform_Services/M365_Backup/index.md
+++ b/docs/Platform_Services/M365_Backup/index.md
@@ -31,13 +31,13 @@ Your CSM will arrange for an account to be created for you in the AUCyber Portal
 
 Once your account has been created, your security contact will be required to sign the Community Rules Information Security Policy (CRISP) electronically in the Portal. The CRISP dictates the behaviours and responsibilities for both AUCyber and all customers that we must jointly adhere to.  
   
-## Configuration of Microsoft M365 Service account
+## Configuration of the Microsoft M365 Veeam Backup App Registration
 
-You will need to configure a Microsoft Veeam Backup Service account. To prevent Microsoft throttling of the backups, we recommend creating 8 users under this account.  
+You will need to register an application in Microsoft Entra ID, grant it the required permissions and upload the certificate provided by AUCyber. The steps are covered in [Configuration of Microsoft M365 Veeam Backup App Registration](./configuration.md).
 
 ## Provide details to AUCyber
 
-The backup service account username and app password need to be provided to AUCyber to complete the setup of your account. These details can be entered via Webex, Zoom, Teams chat or by coming to our office and entering them manually.  
+The Application (client) ID of the registered application and your Microsoft 365 organization name need to be provided to AUCyber to complete the setup of your account. These details can be entered via Webex, Zoom, Teams chat or by coming to our office and entering them manually.  
 
 ## Restore records through the Self-Service portal
 

--- a/known-words.txt
+++ b/known-words.txt
@@ -190,3 +190,5 @@ misconfiguration
 Cyberduck
 cyberduck
 s5cmd
+subfolder
+contoso


### PR DESCRIPTION
## Summary

- Rewrite the Entra ID permission tables to the Veeam Backup for Microsoft 365 v8 permission set (VB365 8.4, app-only authentication). Restores use the application certificate, so both tables are Application type; delegated permissions and the device code flow are gone.
- Add the Microsoft Graph mailbox permissions (User.Read.All, MailboxItem.ImportExport.All, MailboxFolder.ReadWrite.All, MailboxItem.Read.All) needed before Microsoft retires EWS in Exchange Online on 1 October 2026 (Veeam KB4820), plus ChannelMember.Read.All / ChannelMember.ReadWrite.All and Files.ReadWrite.All for Teams.
- Drop the backup service account prerequisite and the old "create 8 users" throttling advice; the app registration with certificate covers backup and restore.
- configuration.md now links to the permission tables instead of duplicating them, and gets Microsoft Entra ID naming, entra.microsoft.com paths, fixed list numbering and learn.microsoft.com links. Restore Portal flow unchanged (still current in v8).
- Add subfolder and contoso to known-words.txt for spellcheck.

mkdocs build --strict passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)