### PR TITLE
docs: set M365 Backup nav order

### DIFF
--- a/docs/Platform_Services/M365_Backup/.pages
+++ b/docs/Platform_Services/M365_Backup/.pages
@@ -1,0 +1,9 @@
+nav:
+    - index.md
+    - configuration.md
+    - EntraID_application_permission_requirements.md
+    - Adding_Restore_Operator_Group.md
+    - Certificate_Update.md
+    - guide_to_veeam_restore_portal.md
+    - M365_Backup_common_errors_and_actions.md
+    - FAQ's.md


### PR DESCRIPTION
Add a .pages nav for the M365 Backup section: app registration configuration first (after the overview), Entra ID permission requirements directly under it, FAQs at the bottom. Other pages keep their alphabetical order.

mkdocs build --strict passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)